### PR TITLE
fix: add cryptography dependency

### DIFF
--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -17,7 +17,7 @@ phonenumbers==8.12.19
 promise==2.3
 psycopg2-binary==2.9.1
 PyJWT==1.7.1
-cryptographqy==35.0.0
+cryptography==35.0.0
 google-api-python-client==2.23.0
 oauth2client==4.1.3
 pandas==1.3.0

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -16,7 +16,8 @@ gunicorn==20.0.4
 phonenumbers==8.12.19
 promise==2.3
 psycopg2-binary==2.9.1
-PyJWT[crypto]==1.7.1
+PyJWT==1.7.1
+cryptographqy==35.0.0
 google-api-python-client==2.23.0
 oauth2client==4.1.3
 pandas==1.3.0


### PR DESCRIPTION
## Proposed Changes

- Add cryptography as an explicit dependency as it is not retrieved using the `PyJWT[crypto]`-syntax.

## Types of Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [x] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

-

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [ ] I am pleased with the readability of the code (if not, state where you need input)
- [ ] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
